### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,8 @@ jobs:
   build:
     name: Build Docusaurus
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Potential fix for [https://github.com/guardiafinance/hub/security/code-scanning/2](https://github.com/guardiafinance/hub/security/code-scanning/2)

To fix the issue, we will add a `permissions` block to the `build` job. Since the `build` job only needs to read repository contents (e.g., to fetch code and dependencies), we will set `contents: read` as the minimal required permission. This change ensures that the job does not inherit broader permissions from the repository or organization.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
