### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -1,4 +1,6 @@
 name: Test deployment
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/guardiafinance/.github/security/code-scanning/1](https://github.com/guardiafinance/.github/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow file to explicitly set the minimum required permissions for the `GITHUB_TOKEN`. Since the workflow only checks out code and builds the project, it only needs read access to repository contents. The best way to do this is to add the following at the top level of the workflow file (just after the `name:` line and before `on:`):  
```yaml
permissions:
  contents: read
```
This ensures that all jobs in the workflow inherit these minimal permissions unless overridden. No other changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
